### PR TITLE
fixes #34

### DIFF
--- a/src/ChangelogGenerator/ChangelogConfig.php
+++ b/src/ChangelogGenerator/ChangelogConfig.php
@@ -28,8 +28,14 @@ class ChangelogConfig
     /** @var bool */
     private $includeOpen;
 
+    /** @var bool */
+    private $includeDate = false;
+
     /** @var mixed[] */
-    private $options = ['rootGitHubUrl' => self::DEFAULT_ROOT_GITHUB_URL];
+    private $options = [
+        'rootGitHubUrl' => self::DEFAULT_ROOT_GITHUB_URL,
+        'dateFormat' => 'Y-m-d',
+    ];
 
     /**
      * @param string[] $labels
@@ -113,6 +119,18 @@ class ChangelogConfig
     public function setIncludeOpen(bool $includeOpen) : self
     {
         $this->includeOpen = $includeOpen;
+
+        return $this;
+    }
+
+    public function shouldIncludeDate() : bool
+    {
+        return $this->includeDate;
+    }
+
+    public function setIncludeDate(bool $includeDate) : self
+    {
+        $this->includeDate = $includeDate;
 
         return $this;
     }

--- a/src/ChangelogGenerator/ChangelogGenerator.php
+++ b/src/ChangelogGenerator/ChangelogGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ChangelogGenerator;
 
+use DateTime;
 use Symfony\Component\Console\Output\OutputInterface;
 use function array_filter;
 use function array_map;
@@ -32,8 +33,15 @@ class ChangelogGenerator
         $issues      = $this->issueRepository->getMilestoneIssues($changelogConfig);
         $issueGroups = $this->issueGrouper->groupIssues($issues, $changelogConfig);
 
+        $date = '';
+
+        if ($changelogConfig->shouldIncludeDate()) {
+            $dateTime = new DateTime('now');
+            $date     = ' - [' . $dateTime->format($changelogConfig->getOption('dateFormat')) . ']';
+        }
+
         $output->writeln([
-            sprintf('## %s', $changelogConfig->getMilestone()),
+            sprintf('## %s%s', $changelogConfig->getMilestone(), $date),
             '',
             sprintf('- Total issues resolved: **%s**', $this->getNumberOfIssues($issues)),
             sprintf('- Total pull requests resolved: **%s**', $this->getNumberOfPullRequests($issues)),

--- a/tests/ChangelogGenerator/Tests/ChangelogConfigTest.php
+++ b/tests/ChangelogGenerator/Tests/ChangelogConfigTest.php
@@ -77,7 +77,7 @@ final class ChangelogConfigTest extends TestCase
 
     public function testGetSetOptions() : void
     {
-        self::assertEquals(['rootGitHubUrl' => 'https://api.github.com'], $this->changelogConfig->getOptions());
+        self::assertEquals(['rootGitHubUrl' => 'https://api.github.com', 'dateFormat' => 'Y-m-d'], $this->changelogConfig->getOptions());
 
         $this->changelogConfig->setOptions(['rootGitHubUrl' => 'https://git.mycompany.com/api/v3']);
 

--- a/tests/ChangelogGenerator/Tests/ChangelogGeneratorTest.php
+++ b/tests/ChangelogGenerator/Tests/ChangelogGeneratorTest.php
@@ -10,11 +10,16 @@ use ChangelogGenerator\Issue;
 use ChangelogGenerator\IssueGroup;
 use ChangelogGenerator\IssueGrouper;
 use ChangelogGenerator\IssueRepository;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class ChangelogGeneratorTest extends TestCase
 {
+    private const USER       = 'jwage';
+    private const REPOSITORY = 'changelog-generator';
+    private const MILESTONE  = '1.0';
+
     /** @var \PHPUnit_Framework_MockObject_MockObject|IssueRepository */
     private $issueRepository;
 
@@ -26,23 +31,9 @@ final class ChangelogGeneratorTest extends TestCase
 
     public function testGenerate() : void
     {
-        $user       = 'jwage';
-        $repository = 'changelog-generator';
-        $milestone  = '1.0';
+        [$issue1, $issue2, $pullRequest1, $pullRequest2, $issueGroup, $milestoneIssues, $issueGroups] = $this->arrangeIssues();
 
-        $output = $this->createMock(OutputInterface::class);
-
-        $issue1       = $this->createMock(Issue::class);
-        $issue2       = $this->createMock(Issue::class);
-        $pullRequest1 = $this->createMock(Issue::class);
-        $pullRequest2 = $this->createMock(Issue::class);
-
-        $issueGroup = $this->createMock(IssueGroup::class);
-
-        $milestoneIssues = [$issue1, $issue2, $pullRequest1, $pullRequest2];
-        $issueGroups     = [$issueGroup];
-
-        $changelogConfig = new ChangelogConfig($user, $repository, $milestone, []);
+        $changelogConfig = new ChangelogConfig(self::USER, self::REPOSITORY, self::MILESTONE, []);
 
         $this->issueRepository->expects(self::once())
             ->method('getMilestoneIssues')
@@ -94,6 +85,8 @@ final class ChangelogGeneratorTest extends TestCase
             ->method('getUser')
             ->willReturn('romanb');
 
+        $output = $this->arrangeConsoleOutput();
+
         $output->expects(self::at(0))
             ->method('writeln')
             ->with([
@@ -104,17 +97,77 @@ final class ChangelogGeneratorTest extends TestCase
                 '- Total contributors: **3**',
             ]);
 
-        $output->expects(self::at(1))
+        $this->changelogGenerator->generate($changelogConfig, $output);
+    }
+
+    public function testGenerateWithDate() : void
+    {
+        [$issue1, $issue2, $pullRequest1, $pullRequest2, $issueGroup, $milestoneIssues, $issueGroups] = $this->arrangeIssues();
+
+        $changelogConfig = new ChangelogConfig(self::USER, self::REPOSITORY, self::MILESTONE, []);
+        $changelogConfig->setIncludeDate(true);
+
+        $this->issueRepository->expects(self::once())
+            ->method('getMilestoneIssues')
+            ->with($changelogConfig)
+            ->willReturn($milestoneIssues);
+
+        $this->issueGrouper->expects(self::once())
+            ->method('groupIssues')
+            ->with($milestoneIssues)
+            ->willReturn($issueGroups);
+
+        $issueGroup->expects(self::once())
+            ->method('getName')
+            ->willReturn('Enhancement');
+
+        $issueGroup->expects(self::once())
+            ->method('getIssues')
+            ->willReturn([$issue1, $issue2]);
+
+        $issue1->expects(self::once())
+            ->method('render')
+            ->willReturn('Issue #1');
+
+        $issue1->expects(self::once())
+            ->method('getUser')
+            ->willReturn('jwage');
+
+        $issue2->expects(self::once())
+            ->method('render')
+            ->willReturn('Issue #2');
+
+        $issue2->expects(self::once())
+            ->method('getUser')
+            ->willReturn('jwage');
+
+        $pullRequest1->expects(self::any())
+            ->method('isPullRequest')
+            ->willReturn(true);
+
+        $pullRequest1->expects(self::once())
+            ->method('getUser')
+            ->willReturn('Ocramius');
+
+        $pullRequest2->expects(self::any())
+            ->method('isPullRequest')
+            ->willReturn(true);
+
+        $pullRequest2->expects(self::once())
+            ->method('getUser')
+            ->willReturn('romanb');
+
+        $output = $this->arrangeConsoleOutput();
+
+        $output->expects(self::at(0))
             ->method('writeln')
             ->with([
+                '## 1.0 - [' . (new \DateTime('now'))->format($changelogConfig->getOption('dateFormat')) . ']',
                 '',
-                '### Enhancement',
-                '',
+                '- Total issues resolved: **2**',
+                '- Total pull requests resolved: **2**',
+                '- Total contributors: **3**',
             ]);
-
-        $output->expects(self::at(2))
-            ->method('writeln')
-            ->with('Issue #1');
 
         $this->changelogGenerator->generate($changelogConfig, $output);
     }
@@ -128,5 +181,44 @@ final class ChangelogGeneratorTest extends TestCase
             $this->issueRepository,
             $this->issueGrouper
         );
+    }
+
+    /**
+     * @return mixed[]
+     */
+    private function arrangeIssues() : array
+    {
+        $issue1       = $this->createMock(Issue::class);
+        $issue2       = $this->createMock(Issue::class);
+        $pullRequest1 = $this->createMock(Issue::class);
+        $pullRequest2 = $this->createMock(Issue::class);
+
+        $issueGroup = $this->createMock(IssueGroup::class);
+
+        $milestoneIssues = [$issue1, $issue2, $pullRequest1, $pullRequest2];
+        $issueGroups     = [$issueGroup];
+
+        return [$issue1, $issue2, $pullRequest1, $pullRequest2, $issueGroup, $milestoneIssues, $issueGroups];
+    }
+
+    /**
+     * @return MockObject|OutputInterface
+     */
+    private function arrangeConsoleOutput()
+    {
+        $output = $this->createMock(OutputInterface::class);
+
+        $output->expects(self::at(1))
+            ->method('writeln')
+            ->with([
+                '',
+                '### Enhancement',
+                '',
+            ]);
+
+        $output->expects(self::at(2))
+            ->method('writeln')
+            ->with('Issue #1');
+        return $output;
     }
 }

--- a/tests/ChangelogGenerator/Tests/Functional/ConsoleTest.php
+++ b/tests/ChangelogGenerator/Tests/Functional/ConsoleTest.php
@@ -53,7 +53,6 @@ final class ConsoleTest extends TestCase
         $this->application->run($input, $output);
     }
 
-
     public function testGenerateInvalidConfig() : void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -471,6 +470,50 @@ final class ConsoleTest extends TestCase
         $output = $this->createMock(OutputInterface::class);
 
         $changelogConfig = new ChangelogConfig('doctrine', 'migrations', '2.0', ['Enhancement', 'Bug']);
+
+        $this->changelogGenerator->expects(self::once())
+            ->method('generate')
+            ->with($changelogConfig, $output);
+
+        $this->application->run($input, $output);
+    }
+
+    public function testGenerateWithDate() : void
+    {
+        $input = new ArrayInput([
+            'command'       => 'generate',
+            '--user'        => 'jwage',
+            '--repository'  => 'changelog-generator',
+            '--milestone'   => '1.0',
+            '--include-date' => null,
+        ]);
+
+        $output = $this->createMock(OutputInterface::class);
+
+        $changelogConfig = new ChangelogConfig('jwage', 'changelog-generator', '1.0', []);
+        $changelogConfig->setIncludeDate(true);
+
+        $this->changelogGenerator->expects(self::once())
+            ->method('generate')
+            ->with($changelogConfig, $output);
+
+        $this->application->run($input, $output);
+    }
+
+    public function testGenerateConfigOverrideDate() : void
+    {
+        $input = new ArrayInput([
+            'command'       => 'generate',
+            '--user'        => 'jwage',
+            '--repository'  => 'changelog-generator',
+            '--milestone'   => '1.0',
+            '--include-date' => 0,
+        ]);
+
+        $output = $this->createMock(OutputInterface::class);
+
+        $changelogConfig = new ChangelogConfig('jwage', 'changelog-generator', '1.0', []);
+        $changelogConfig->setIncludeDate(false);
 
         $this->changelogGenerator->expects(self::once())
             ->method('generate')

--- a/tests/ChangelogGenerator/Tests/IssueTest.php
+++ b/tests/ChangelogGenerator/Tests/IssueTest.php
@@ -77,7 +77,7 @@ final class IssueTest extends TestCase
 
         $this->issue->setLinkedPullRequest($linkedPullRequest);
 
-        self::assertSame($linkedPullRequest, $this->issue->getLinkedPullRequest());
+        self::assertInstanceOf(Issue::class, $this->issue->getLinkedPullRequest());
     }
 
     public function testLinkedIssue() : void
@@ -88,7 +88,7 @@ final class IssueTest extends TestCase
 
         $this->issue->setLinkedIssue($linkedIssue);
 
-        self::assertSame($linkedIssue, $this->issue->getLinkedIssue());
+        self::assertInstanceOf(Issue::class, $this->issue->getLinkedIssue());
     }
 
     public function testRender() : void


### PR DESCRIPTION
Added a new option `include-date` to the command
Added new functions to ChangelogConfig
Added a new option `date_format` to ChangelogConfig 

With the new option the new Changelog looks like this
```markdown
## v1.0.0 - 2018.1.1
```