### PR TITLE
Generate alternative (Setext, without #) Markdown format for headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": "^7.1",
+        "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.3",
         "ocramius/package-versions": "^1.3",
         "symfony/console": "^4.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b6cc9551c921f71f428ce2333407a664",
+    "content-hash": "a497de9eec0f62eb120953ff36c3add4",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -3019,7 +3019,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": "^7.1",
+        "ext-mbstring": "*"
     },
     "platform-dev": []
 }

--- a/src/ChangelogGenerator/ChangelogGenerator.php
+++ b/src/ChangelogGenerator/ChangelogGenerator.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace ChangelogGenerator;
 
 use Symfony\Component\Console\Output\OutputInterface;
+use const PHP_EOL;
 use function array_filter;
 use function array_map;
 use function array_unique;
 use function count;
+use function mb_strlen;
 use function sprintf;
+use function str_repeat;
 
 class ChangelogGenerator
 {
@@ -33,7 +36,12 @@ class ChangelogGenerator
         $issueGroups = $this->issueGrouper->groupIssues($issues, $changelogConfig);
 
         $output->writeln([
-            sprintf('## %s', $changelogConfig->getMilestone()),
+            sprintf(
+                '%s%s%s',
+                $changelogConfig->getMilestone(),
+                PHP_EOL,
+                str_repeat('=', mb_strlen($changelogConfig->getMilestone()))
+            ),
             '',
             sprintf('- Total issues resolved: **%s**', $this->getNumberOfIssues($issues)),
             sprintf('- Total pull requests resolved: **%s**', $this->getNumberOfPullRequests($issues)),
@@ -43,7 +51,12 @@ class ChangelogGenerator
         foreach ($issueGroups as $issueGroup) {
             $output->writeln([
                 '',
-                sprintf('### %s', $issueGroup->getName()),
+                sprintf(
+                    '%s%s%s',
+                    $issueGroup->getName(),
+                    PHP_EOL,
+                    str_repeat('-', mb_strlen($issueGroup->getName()))
+                ),
                 '',
             ]);
 

--- a/tests/ChangelogGenerator/Tests/ChangelogGeneratorTest.php
+++ b/tests/ChangelogGenerator/Tests/ChangelogGeneratorTest.php
@@ -12,6 +12,8 @@ use ChangelogGenerator\IssueGrouper;
 use ChangelogGenerator\IssueRepository;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
+use const PHP_EOL;
+use function sprintf;
 
 final class ChangelogGeneratorTest extends TestCase
 {
@@ -54,7 +56,7 @@ final class ChangelogGeneratorTest extends TestCase
             ->with($milestoneIssues)
             ->willReturn($issueGroups);
 
-        $issueGroup->expects(self::once())
+        $issueGroup->expects(self::exactly(2))
             ->method('getName')
             ->willReturn('Enhancement');
 
@@ -97,7 +99,7 @@ final class ChangelogGeneratorTest extends TestCase
         $output->expects(self::at(0))
             ->method('writeln')
             ->with([
-                '## 1.0',
+                sprintf('1.0%s===', PHP_EOL),
                 '',
                 '- Total issues resolved: **2**',
                 '- Total pull requests resolved: **2**',
@@ -108,7 +110,7 @@ final class ChangelogGeneratorTest extends TestCase
             ->method('writeln')
             ->with([
                 '',
-                '### Enhancement',
+                sprintf('Enhancement%s-----------', PHP_EOL),
                 '',
             ]);
 


### PR DESCRIPTION
When the generated changelog is to be used as a tag message, Git treats lines starting with `#` as comments by default. This [can be changed](https://stackoverflow.com/questions/2788092/start-a-git-commit-message-with-a-hashmark) with the `--cleanup=whitespace` option, but it's easy to forget.

https://daringfireball.net/projects/markdown/syntax#header

The differense is changing h2->h1 and h3->h2.

Old:

---
## 0.0.6

- Total issues resolved: **3**
- Total pull requests resolved: **4**
- Total contributors: **2**

### Bug

 - [30: Fix include-open option overriding value in ChangelogConfig.](https://github.com/jwage/changelog-generator/pull/30) thanks to @jwage
 - [29: Fix issue with right square brackets being encoded improperly.](https://github.com/jwage/changelog-generator/pull/29) thanks to @jwage and @Majkl578
 - [28: Take in to consideration filtered labels when generating issue group name](https://github.com/jwage/changelog-generator/pull/28) thanks to @jwage

### Enhancement

 - [25: Add option to include open issues/PRs](https://github.com/jwage/changelog-generator/pull/25) thanks to @Majkl578
---

New:

---
0.0.6
=====

- Total issues resolved: **3**
- Total pull requests resolved: **4**
- Total contributors: **2**

Bug
---

 - [30: Fix include-open option overriding value in ChangelogConfig.](https://github.com/jwage/changelog-generator/pull/30) thanks to @jwage
 - [29: Fix issue with right square brackets being encoded improperly.](https://github.com/jwage/changelog-generator/pull/29) thanks to @jwage and @Majkl578
 - [28: Take in to consideration filtered labels when generating issue group name](https://github.com/jwage/changelog-generator/pull/28) thanks to @jwage

Enhancement
-----------

 - [25: Add option to include open issues/PRs](https://github.com/jwage/changelog-generator/pull/25) thanks to @Majkl578
---

Maybe the label sections are too huge - we can switch to simply bold instead?

If you'd prefer to keep the original syntax too, we can add option for selecting setext/atx format.