### PR TITLE
Handle Issues with empty bodies

### DIFF
--- a/src/ChangelogGenerator/Issue.php
+++ b/src/ChangelogGenerator/Issue.php
@@ -18,7 +18,7 @@ class Issue
     /** @var string */
     private $title;
 
-    /** @var string */
+    /** @var string|null */
     private $body;
 
     /** @var string */
@@ -45,7 +45,7 @@ class Issue
     public function __construct(
         int $number,
         string $title,
-        string $body,
+        ?string $body,
         string $url,
         string $user,
         array $labels,
@@ -70,7 +70,7 @@ class Issue
         return $this->title;
     }
 
-    public function getBody() : string
+    public function getBody() : ?string
     {
         return $this->body;
     }

--- a/src/ChangelogGenerator/IssueGrouper.php
+++ b/src/ChangelogGenerator/IssueGrouper.php
@@ -82,6 +82,10 @@ class IssueGrouper
             }
 
             foreach ($issues as $i) {
+                if ($issue->getBody() === null) {
+                    continue;
+                }
+
                 if ($i->isPullRequest() || strpos($issue->getBody(), '#' . $i->getNumber()) === false) {
                     continue;
                 }

--- a/tests/ChangelogGenerator/Tests/IssueTest.php
+++ b/tests/ChangelogGenerator/Tests/IssueTest.php
@@ -113,6 +113,23 @@ final class IssueTest extends TestCase
         self::assertEquals(' - [2: Test Title](https://www.google.com) thanks to @Ocramius and @jwage', $pullRequest->render());
     }
 
+    public function testEmptyBodyIssuesGetsRendered() : void
+    {
+        $pullRequest = new Issue(
+            3,
+            'PR without body',
+            null,
+            'https://www.google.com',
+            'jwage',
+            ['Bugfix'],
+            true
+        );
+
+        $pullRequest->setLinkedIssue($this->issue);
+
+        self::assertSame(' - [3: PR without body](https://www.google.com) thanks to @jwage', $pullRequest->render());
+    }
+
     protected function setUp() : void
     {
         $this->issue = new Issue(


### PR DESCRIPTION
To reproduce this issue, all you need to do is try to generate a changelog with a pull request with an empty body.