### PR TITLE
Support multiple milestones

### DIFF
--- a/src/ChangelogGenerator/ChangelogConfig.php
+++ b/src/ChangelogGenerator/ChangelogConfig.php
@@ -83,6 +83,7 @@ class ChangelogConfig
         return $this;
     }
 
+    /** @deprecated Deprecated in favour of getMilestones */
     public function getMilestone() : string
     {
         return $this->getFirstMilestone();
@@ -94,6 +95,7 @@ class ChangelogConfig
         return $this->milestones;
     }
 
+    /** @deprecated Deprecated in favour of setMilestones and addMilestone */
     public function setMilestone(string $milestone) : self
     {
         $this->setSingleMilestone($milestone);

--- a/src/ChangelogGenerator/ChangelogConfig.php
+++ b/src/ChangelogGenerator/ChangelogConfig.php
@@ -205,11 +205,11 @@ class ChangelogConfig
         return $this;
     }
 
-    public function getMilestoneIssuesUrl(string $label) : string
+    public function getIssuesUrl(string $milestone, string $label) : string
     {
         $query = urlencode(sprintf(
             'milestone:"%s" repo:%s/%s%s%s',
-            str_replace('"', '\"', $this->getFirstMilestone()),
+            str_replace('"', '\"', $milestone),
             $this->user,
             $this->repository,
             $this->includeOpen ? '' : ' state:closed',
@@ -217,6 +217,11 @@ class ChangelogConfig
         ));
 
         return sprintf('%s/search/issues?q=%s', $this->getRootGitHubUrl(), $query);
+    }
+
+    public function getMilestoneIssuesUrl(string $label) : string
+    {
+        return $this->getIssuesUrl($this->getFirstMilestone(), $label);
     }
 
     public function isValid() : bool

--- a/src/ChangelogGenerator/ChangelogGenerator.php
+++ b/src/ChangelogGenerator/ChangelogGenerator.php
@@ -33,7 +33,7 @@ class ChangelogGenerator
         ChangelogConfig $changelogConfig,
         OutputInterface $output
     ) : void {
-        $issues      = $this->issueRepository->getMilestoneIssues($changelogConfig);
+        $issues      = $this->issueRepository->getIssues($changelogConfig);
         $issueGroups = $this->issueGrouper->groupIssues($issues, $changelogConfig);
 
         $output->writeln([

--- a/src/ChangelogGenerator/Command/GenerateChangelogCommand.php
+++ b/src/ChangelogGenerator/Command/GenerateChangelogCommand.php
@@ -14,6 +14,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
+use function array_push;
+use function array_shift;
 use function assert;
 use function count;
 use function current;
@@ -75,7 +77,7 @@ EOT
             ->addOption(
                 'milestone',
                 null,
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'The milestone to build the changelog for.'
             )
             ->addOption(
@@ -380,8 +382,20 @@ EOT
             $changelogConfig->setRepository($this->getStringOption($input, 'repository'));
         }
 
-        if ($input->getOption('milestone') !== null) {
-            $changelogConfig->setMilestone($this->getStringOption($input, 'milestone'));
+        $milestone = $input->getOption('milestone');
+        if ($milestone !== null) {
+            if (! is_array($milestone)) {
+                $singleMilestone = $milestone;
+                $milestone = [];
+
+                if ($milestone !== '') {
+                    array_push($milestone, $singleMilestone);
+                }
+            }
+
+            if ($milestone !== []) {
+                $changelogConfig->setMilestones(...$milestone);
+            }
         }
 
         if ($input->getOption('label') !== []) {

--- a/src/ChangelogGenerator/Command/GenerateChangelogCommand.php
+++ b/src/ChangelogGenerator/Command/GenerateChangelogCommand.php
@@ -60,6 +60,10 @@ The <info>%command.name%</info> command generates a changelog markdown document 
 You can filter the changelog by label names using the --label option:
 
     <info>%command.full_name% --user=doctrine --repository=migrations --milestone=2.0 --label=Enhancement --label=Bug</info>
+
+You can pass multiple milestones as well:
+
+    <info>%command.full_name% --user=doctrine --repository=migrations --milestone=2.0.5 --milestone=1.10.5 --label=Enhancement --label=Bug</info>
 EOT
             )
             ->addOption(

--- a/src/ChangelogGenerator/IssueFetcher.php
+++ b/src/ChangelogGenerator/IssueFetcher.php
@@ -26,27 +26,29 @@ class IssueFetcher
 
         $issues = [];
 
-        foreach ($labels as $label) {
-            $url = $changelogConfig->getMilestoneIssuesUrl($label);
+        foreach ($changelogConfig->getMilestones() as $milestone) {
+            foreach ($labels as $label) {
+                $url = $changelogConfig->getIssuesUrl($milestone, $label);
 
-            while (true) {
-                $response = $this->issueClient->execute($url, $changelogConfig->getGitHubCredentials());
+                while (true) {
+                    $response = $this->issueClient->execute($url, $changelogConfig->getGitHubCredentials());
 
-                $body = $response->getBody();
+                    $body = $response->getBody();
 
-                foreach ($body['items'] as $item) {
-                    $issues[] = $item;
+                    foreach ($body['items'] as $item) {
+                        $issues[] = $item;
+                    }
+
+                    $nextUrl = $response->getNextUrl();
+
+                    if ($nextUrl !== null) {
+                        $url = $nextUrl;
+
+                        continue;
+                    }
+
+                    break;
                 }
-
-                $nextUrl = $response->getNextUrl();
-
-                if ($nextUrl !== null) {
-                    $url = $nextUrl;
-
-                    continue;
-                }
-
-                break;
             }
         }
 

--- a/src/ChangelogGenerator/IssueFetcher.php
+++ b/src/ChangelogGenerator/IssueFetcher.php
@@ -19,7 +19,7 @@ class IssueFetcher
     /**
      * @return mixed[]
      */
-    public function fetchMilestoneIssues(ChangelogConfig $changelogConfig) : array
+    public function fetchIssues(ChangelogConfig $changelogConfig) : array
     {
         $labels = $changelogConfig->getLabels();
         $labels = count($labels) === 0 ? [''] : $labels;
@@ -53,5 +53,13 @@ class IssueFetcher
         }
 
         return $issues;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function fetchMilestoneIssues(ChangelogConfig $changelogConfig) : array
+    {
+        return $this->fetchIssues($changelogConfig);
     }
 }

--- a/src/ChangelogGenerator/IssueFetcher.php
+++ b/src/ChangelogGenerator/IssueFetcher.php
@@ -56,6 +56,8 @@ class IssueFetcher
     }
 
     /**
+     * @deprecated Deprecated in favour of fetchIssues
+     *
      * @return mixed[]
      */
     public function fetchMilestoneIssues(ChangelogConfig $changelogConfig) : array

--- a/src/ChangelogGenerator/IssueRepository.php
+++ b/src/ChangelogGenerator/IssueRepository.php
@@ -21,9 +21,9 @@ class IssueRepository
     /**
      * @return Issue[]
      */
-    public function getMilestoneIssues(ChangelogConfig $changelogConfig) : array
+    public function getIssues(ChangelogConfig $changelogConfig) : array
     {
-        $issuesData = $this->issueFetcher->fetchMilestoneIssues($changelogConfig);
+        $issuesData = $this->issueFetcher->fetchIssues($changelogConfig);
 
         $issues = [];
 
@@ -36,5 +36,13 @@ class IssueRepository
         }
 
         return $issues;
+    }
+
+    /**
+     * @return Issue[]
+     */
+    public function getMilestoneIssues(ChangelogConfig $changelogConfig) : array
+    {
+        return $this->getIssues($changelogConfig);
     }
 }

--- a/src/ChangelogGenerator/IssueRepository.php
+++ b/src/ChangelogGenerator/IssueRepository.php
@@ -39,6 +39,8 @@ class IssueRepository
     }
 
     /**
+     * @deprecated Deprecated in favour of getIssues
+     *
      * @return Issue[]
      */
     public function getMilestoneIssues(ChangelogConfig $changelogConfig) : array

--- a/src/ChangelogGenerator/IssueRepository.php
+++ b/src/ChangelogGenerator/IssueRepository.php
@@ -28,6 +28,10 @@ class IssueRepository
         $issues = [];
 
         foreach ($issuesData as $issue) {
+            if (isset($issues[$issue['number']])) {
+                continue;
+            }
+
             $issues[$issue['number']] = $this->issueFactory->create($issue);
         }
 

--- a/tests/ChangelogGenerator/Tests/ChangelogConfigTest.php
+++ b/tests/ChangelogGenerator/Tests/ChangelogConfigTest.php
@@ -59,6 +59,25 @@ final class ChangelogConfigTest extends TestCase
         self::assertSame('1.0', $this->changelogConfig->getMilestone());
     }
 
+    public function testSetMilestones() : void
+    {
+        self::assertSame($this->milestone, $this->changelogConfig->getMilestone());
+
+        $this->changelogConfig->setMilestones('1.1', '1.2');
+
+        self::assertSame(['1.1', '1.2'], $this->changelogConfig->getMilestones());
+    }
+
+    public function testAddMilestone() : void
+    {
+        self::assertSame($this->milestone, $this->changelogConfig->getMilestone());
+
+        $this->changelogConfig->addMilestone('1.1', '1.2');
+
+        self::assertSame('1.0', $this->changelogConfig->getMilestone());
+        self::assertSame(['1.0', '1.1', '1.2'], $this->changelogConfig->getMilestones());
+    }
+
     public function testGetSetLabels() : void
     {
         self::assertSame($this->labels, $this->changelogConfig->getLabels());

--- a/tests/ChangelogGenerator/Tests/ChangelogConfigTest.php
+++ b/tests/ChangelogGenerator/Tests/ChangelogConfigTest.php
@@ -119,30 +119,35 @@ final class ChangelogConfigTest extends TestCase
         self::assertSame('https://api.github.com/search/issues?q=milestone%3A%221.0%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed+label%3AEnhancement', $this->changelogConfig->getMilestoneIssuesUrl('Enhancement'));
     }
 
-    public function testGetMilestoneIssuesUrlNoLabel() : void
+    public function testGetIssuesUrl() : void
     {
-        self::assertSame('https://api.github.com/search/issues?q=milestone%3A%221.0%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed', $this->changelogConfig->getMilestoneIssuesUrl(''));
+        self::assertSame('https://api.github.com/search/issues?q=milestone%3A%221.1%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed+label%3AEnhancement', $this->changelogConfig->getIssuesUrl('1.1', 'Enhancement'));
     }
 
-    public function testGetMilestoneIssuesUrlWithCustomRootGitHubUrl() : void
+    public function testGetIssuesUrlNoLabel() : void
+    {
+        self::assertSame('https://api.github.com/search/issues?q=milestone%3A%221.1%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed', $this->changelogConfig->getIssuesUrl('1.1', ''));
+    }
+
+    public function testGetIssuesUrlWithCustomRootGitHubUrl() : void
     {
         $this->changelogConfig->setOptions(['rootGitHubUrl' => 'https://git.mycompany.com/api/v3']);
 
-        self::assertSame('https://git.mycompany.com/api/v3/search/issues?q=milestone%3A%221.0%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed+label%3AEnhancement', $this->changelogConfig->getMilestoneIssuesUrl('Enhancement'));
+        self::assertSame('https://git.mycompany.com/api/v3/search/issues?q=milestone%3A%221.1%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed+label%3AEnhancement', $this->changelogConfig->getIssuesUrl('1.1', 'Enhancement'));
     }
 
-    public function testGetMilestoneIssuesUrlWithMissingRootGitHubUrl() : void
+    public function testGetIssuesUrlWithMissingRootGitHubUrl() : void
     {
         $this->changelogConfig->setOptions([]);
 
-        self::assertSame('https://api.github.com/search/issues?q=milestone%3A%221.0%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed+label%3AEnhancement', $this->changelogConfig->getMilestoneIssuesUrl('Enhancement'));
+        self::assertSame('https://api.github.com/search/issues?q=milestone%3A%221.1%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed+label%3AEnhancement', $this->changelogConfig->getIssuesUrl('1.1', 'Enhancement'));
     }
 
-    public function testGetMilestoneIssuesUrlWithOpenIncluded() : void
+    public function testGetIssuesUrlWithOpenIncluded() : void
     {
         $this->changelogConfig->setIncludeOpen(true);
 
-        self::assertSame('https://api.github.com/search/issues?q=milestone%3A%221.0%22+repo%3Ajwage%2Fchangelog-generator+label%3AEnhancement', $this->changelogConfig->getMilestoneIssuesUrl('Enhancement'));
+        self::assertSame('https://api.github.com/search/issues?q=milestone%3A%221.1%22+repo%3Ajwage%2Fchangelog-generator+label%3AEnhancement', $this->changelogConfig->getIssuesUrl('1.1', 'Enhancement'));
     }
 
     public function testIsValid() : void

--- a/tests/ChangelogGenerator/Tests/ChangelogGeneratorTest.php
+++ b/tests/ChangelogGenerator/Tests/ChangelogGeneratorTest.php
@@ -56,7 +56,7 @@ final class ChangelogGeneratorTest extends TestCase
             ->setShowContributors(true);
 
         $this->issueRepository->expects(self::once())
-            ->method('getMilestoneIssues')
+            ->method('getIssues')
             ->with($changelogConfig)
             ->willReturn($milestoneIssues);
 

--- a/tests/ChangelogGenerator/Tests/IssueFetcherTest.php
+++ b/tests/ChangelogGenerator/Tests/IssueFetcherTest.php
@@ -21,8 +21,10 @@ final class IssueFetcherTest extends TestCase
 
     public function testFetchMilestoneIssues() : void
     {
-        $response1 = new IssueClientResponse(['items' => [1]], 'https://www.google.com');
+        $response1 = new IssueClientResponse(['items' => [1]], 'https://api.github.com/search/issues?q=milestone%3A%221.0%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed%2Fnext');
         $response2 = new IssueClientResponse(['items' => [2]], null);
+        $response3 = new IssueClientResponse(['items' => [1]], 'https://api.github.com/search/issues?q=milestone%3A%221.1%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed%2Fnext');
+        $response4 = new IssueClientResponse(['items' => [3]], null);
 
         $this->issueClient->expects(self::at(0))
             ->method('execute')
@@ -31,14 +33,25 @@ final class IssueFetcherTest extends TestCase
 
         $this->issueClient->expects(self::at(1))
             ->method('execute')
-            ->with('https://www.google.com')
+            ->with('https://api.github.com/search/issues?q=milestone%3A%221.0%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed%2Fnext')
             ->willReturn($response2);
 
+        $this->issueClient->expects(self::at(2))
+            ->method('execute')
+            ->with('https://api.github.com/search/issues?q=milestone%3A%221.1%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed')
+            ->willReturn($response3);
+
+        $this->issueClient->expects(self::at(3))
+            ->method('execute')
+            ->with('https://api.github.com/search/issues?q=milestone%3A%221.1%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed%2Fnext')
+            ->willReturn($response4);
+
         $changelogConfig = new ChangelogConfig('jwage', 'changelog-generator', '1.0', []);
+        $changelogConfig->addMilestone('1.1');
 
         $issues = $this->issueFetcher->fetchMilestoneIssues($changelogConfig);
 
-        self::assertSame([1, 2], $issues);
+        self::assertSame([1, 2, 1, 3], $issues);
     }
 
     protected function setUp() : void

--- a/tests/ChangelogGenerator/Tests/IssueFetcherTest.php
+++ b/tests/ChangelogGenerator/Tests/IssueFetcherTest.php
@@ -19,7 +19,7 @@ final class IssueFetcherTest extends TestCase
     /** @var IssueFetcher */
     private $issueFetcher;
 
-    public function testFetchMilestoneIssues() : void
+    public function testFetchIssues() : void
     {
         $response1 = new IssueClientResponse(['items' => [1]], 'https://api.github.com/search/issues?q=milestone%3A%221.0%22+repo%3Ajwage%2Fchangelog-generator+state%3Aclosed%2Fnext');
         $response2 = new IssueClientResponse(['items' => [2]], null);
@@ -49,7 +49,7 @@ final class IssueFetcherTest extends TestCase
         $changelogConfig = new ChangelogConfig('jwage', 'changelog-generator', '1.0', []);
         $changelogConfig->addMilestone('1.1');
 
-        $issues = $this->issueFetcher->fetchMilestoneIssues($changelogConfig);
+        $issues = $this->issueFetcher->fetchIssues($changelogConfig);
 
         self::assertSame([1, 2, 1, 3], $issues);
     }

--- a/tests/ChangelogGenerator/Tests/IssueRepositoryTest.php
+++ b/tests/ChangelogGenerator/Tests/IssueRepositoryTest.php
@@ -47,6 +47,14 @@ final class IssueRepositoryTest extends TestCase
                     'user' => ['login' => 'jwage'],
                     'labels' => [['name' => 'Bug']],
                 ],
+                [
+                    'number' => 1,
+                    'title' => 'Issue #1',
+                    'body' => 'Issue #1 Body',
+                    'html_url' => 'https://github.com/jwage/changelog-generator/issue/1',
+                    'user' => ['login' => 'jwage'],
+                    'labels' => [['name' => 'Enhancement']],
+                ],
             ]);
 
         $issue1 = $this->createMock(Issue::class);

--- a/tests/ChangelogGenerator/Tests/IssueRepositoryTest.php
+++ b/tests/ChangelogGenerator/Tests/IssueRepositoryTest.php
@@ -23,12 +23,12 @@ final class IssueRepositoryTest extends TestCase
     /** @var IssueRepository */
     private $issueRepository;
 
-    public function testGetMilestoneIssues() : void
+    public function testGetIssues() : void
     {
         $changelogConfig = new ChangelogConfig('jwage', 'changelog-generator', '1.0', []);
 
         $this->issueFetcher->expects(self::once())
-            ->method('fetchMilestoneIssues')
+            ->method('fetchIssues')
             ->with($changelogConfig)
             ->willReturn([
                 [
@@ -84,7 +84,7 @@ final class IssueRepositoryTest extends TestCase
             ])
             ->willReturn($issue2);
 
-        $issues = $this->issueRepository->getMilestoneIssues($changelogConfig);
+        $issues = $this->issueRepository->getIssues($changelogConfig);
 
         self::assertCount(2, $issues);
         self::assertSame($issue1, $issues[1]);


### PR DESCRIPTION
This PR adds support for having multiple milestones in a changelog configuration. This helps when assembling changelogs for patch releases that include changes from a different release. For example, release 1.1.5 includes issues 1, 2, 3. Release 2.0.5, released at the same time, includes issues 1, 2, 3, as well as 4 and 5. Since GitHub issues can't have multiple milestones, we add support for reading issues from multiple milestones.

This PR also deprecates some legacy API to adjust the naming to the new functionality.