### PR TITLE
Allow setting of non-grouped label

### DIFF
--- a/src/ChangelogGenerator/ChangelogConfig.php
+++ b/src/ChangelogGenerator/ChangelogConfig.php
@@ -22,6 +22,8 @@ class ChangelogConfig
     /** @var string[] */
     private array $labels;
 
+    private ?string $nonGroupedLabel = null;
+
     private bool $includeOpen;
 
     private bool $showContributors = false;
@@ -101,6 +103,18 @@ class ChangelogConfig
     public function setLabels(array $labels): self
     {
         $this->labels = $labels;
+
+        return $this;
+    }
+
+    public function getNonGroupedLabel(): ?string
+    {
+        return $this->nonGroupedLabel;
+    }
+
+    public function setNonGroupedLabel(string $nonGroupedLabel): self
+    {
+        $this->nonGroupedLabel = $nonGroupedLabel;
 
         return $this;
     }

--- a/src/ChangelogGenerator/Command/GenerateChangelogCommand.php
+++ b/src/ChangelogGenerator/Command/GenerateChangelogCommand.php
@@ -104,6 +104,12 @@ EOT
                 'The labels to generate a changelog for.'
             )
             ->addOption(
+                'non-grouped-label',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Provide a label for any item that isn\'t grouped under any other label.'
+            )
+            ->addOption(
                 'config',
                 'c',
                 InputOption::VALUE_REQUIRED,
@@ -384,6 +390,10 @@ EOT
 
         if ($input->getOption('label') !== []) {
             $changelogConfig->setLabels($this->getArrayOption($input, 'label'));
+        }
+
+        if ($input->getOption('non-grouped-label') !== null) {
+            $changelogConfig->setNonGroupedLabel($this->getStringOption($input, 'non-grouped-label'));
         }
 
         if ($input->getOption('include-open') !== '') {

--- a/src/ChangelogGenerator/IssueGrouper.php
+++ b/src/ChangelogGenerator/IssueGrouper.php
@@ -56,6 +56,10 @@ class IssueGrouper
             $labels = array_intersect($issue->getLabels(), $labelFilters);
         }
 
+        if ($changelogConfig->getNonGroupedLabel() !== null && count($labels) === 0) {
+            $labels = [$changelogConfig->getNonGroupedLabel()];
+        }
+
         return implode(',', $labels);
     }
 

--- a/tests/ChangelogGenerator/Tests/Functional/ConsoleTest.php
+++ b/tests/ChangelogGenerator/Tests/Functional/ConsoleTest.php
@@ -283,6 +283,28 @@ final class ConsoleTest extends TestCase
         $this->application->run($input, $output);
     }
 
+    public function testGenerateNonGroupedLabel(): void
+    {
+        $input = new ArrayInput([
+            'command'             => 'generate',
+            '--user'              => 'jwage',
+            '--repository'        => 'changelog-generator',
+            '--milestone'         => '1.0',
+            '--label'             => ['Enhancement', 'Bug'],
+            '--non-grouped-label' => 'Non Grouped',
+        ]);
+
+        $output = $this->createMock(OutputInterface::class);
+
+        $changelogConfig = (new ChangelogConfig('jwage', 'changelog-generator', '1.0', ['Enhancement', 'Bug']))->setNonGroupedLabel('Non Grouped');
+
+        $this->changelogGenerator->expects(self::once())
+            ->method('generate')
+            ->with($changelogConfig, $output);
+
+        $this->application->run($input, $output);
+    }
+
     public function testGenerateConfig(): void
     {
         $input = new ArrayInput([

--- a/tests/ChangelogGenerator/Tests/IssueGrouperTest.php
+++ b/tests/ChangelogGenerator/Tests/IssueGrouperTest.php
@@ -59,6 +59,53 @@ final class IssueGrouperTest extends TestCase
         self::assertSame($pullRequest4, $issue4->getLinkedPullRequest());
     }
 
+    public function testGroupIssuesWithNonGroupedLabel(): void
+    {
+        $changelogConfig = (new ChangelogConfig())->setNonGroupedLabel('Everything Else');
+
+        $issue1 = new Issue(1, '', '', '', '', ['Enhancement'], false);
+        $issue2 = new Issue(2, '', '', '', '', ['Bug'], false);
+        $issue3 = new Issue(3, '', '', '', '', [], false);
+        $issue4 = new Issue(4, '', '', '', '', ['Enhancement'], false);
+
+        $pullRequest1 = new Issue(5, '', 'Fixes #1', '', '', ['Enhancement'], true);
+        $pullRequest2 = new Issue(6, '', 'Fixes #2', '', '', ['Bug'], true);
+        $pullRequest3 = new Issue(7, '', 'Fixes #3', '', '', ['Bug'], true);
+        $pullRequest4 = new Issue(8, '', 'Fixes #4', '', '', [], true);
+
+        $issues = [
+            $issue1,
+            $issue2,
+            $issue3,
+            $issue4,
+            $pullRequest1,
+            $pullRequest2,
+            $pullRequest3,
+            $pullRequest4,
+        ];
+
+        $issueGroups = $this->issueGrouper->groupIssues($issues, $changelogConfig);
+
+        self::assertCount(3, $issueGroups);
+        self::assertTrue(isset($issueGroups['Enhancement']));
+        self::assertTrue(isset($issueGroups['Bug']));
+        self::assertTrue(isset($issueGroups['Everything Else']));
+        self::assertContains($pullRequest1, $issueGroups['Enhancement']->getIssues());
+        self::assertContains($pullRequest2, $issueGroups['Bug']->getIssues());
+        self::assertContains($pullRequest3, $issueGroups['Bug']->getIssues());
+        self::assertContains($pullRequest4, $issueGroups['Everything Else']->getIssues());
+
+        self::assertSame($issue1, $pullRequest1->getLinkedIssue());
+        self::assertSame($issue2, $pullRequest2->getLinkedIssue());
+        self::assertSame($issue3, $pullRequest3->getLinkedIssue());
+        self::assertSame($issue4, $pullRequest4->getLinkedIssue());
+
+        self::assertSame($pullRequest1, $issue1->getLinkedPullRequest());
+        self::assertSame($pullRequest2, $issue2->getLinkedPullRequest());
+        self::assertSame($pullRequest3, $issue3->getLinkedPullRequest());
+        self::assertSame($pullRequest4, $issue4->getLinkedPullRequest());
+    }
+
     public function testGroupIssuesWithLabelFilters(): void
     {
         $changelogConfig = new ChangelogConfig();
@@ -90,6 +137,40 @@ final class IssueGrouperTest extends TestCase
         self::assertCount(2, $issueGroups);
         self::assertTrue(isset($issueGroups['Enhancement']));
         self::assertTrue(isset($issueGroups['Bug']));
+    }
+
+    public function testGroupIssuesWithLabelFiltersWithNonGroupedLabel(): void
+    {
+        $changelogConfig = (new ChangelogConfig())->setNonGroupedLabel('Everything Else');
+        $changelogConfig->setLabels(['Enhancement', 'Bug']);
+
+        $issue1 = new Issue(1, '', '', '', '', ['Enhancement', 'Other'], false);
+        $issue2 = new Issue(2, '', '', '', '', ['Bug', 'Other'], false);
+        $issue3 = new Issue(3, '', '', '', '', ['Other'], false);
+        $issue4 = new Issue(4, '', '', '', '', ['Enhancement', 'Other'], false);
+
+        $pullRequest1 = new Issue(5, '', 'Fixes #1', '', '', ['Enhancement', 'Other'], true);
+        $pullRequest2 = new Issue(6, '', 'Fixes #2', '', '', ['Bug', 'Other'], true);
+        $pullRequest3 = new Issue(7, '', 'Fixes #3', '', '', ['Bug', 'Other'], true);
+        $pullRequest4 = new Issue(8, '', 'Fixes #4', '', '', ['Other'], true);
+
+        $issues = [
+            $issue1,
+            $issue2,
+            $issue3,
+            $issue4,
+            $pullRequest1,
+            $pullRequest2,
+            $pullRequest3,
+            $pullRequest4,
+        ];
+
+        $issueGroups = $this->issueGrouper->groupIssues($issues, $changelogConfig);
+
+        self::assertCount(3, $issueGroups);
+        self::assertTrue(isset($issueGroups['Enhancement']));
+        self::assertTrue(isset($issueGroups['Bug']));
+        self::assertTrue(isset($issueGroups['Everything Else']));
     }
 
     protected function setUp(): void


### PR DESCRIPTION
This label, when set, will function as a fallback for any items that are not grouped by any label.

Refs: #69